### PR TITLE
when using npm and requires, main entry for package.json is incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
   "os": [ "linux", "darwin" ],
   "dependencies": {},
   "engines": { "node":  ">0.1.90" },
-  "main": "./redis-client"
+  "main": "./lib/redis-client"
 }


### PR DESCRIPTION
So it should work without monkeying around with the paths:

%  node
Type '.help' for options.
node> var sys = require("sys");
node> var client = require("redis-client").createClient();
node> 
